### PR TITLE
Add zsh and bash-completion

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -172,6 +172,7 @@ RUN \
   apt-get update && \
   apt-get dist-upgrade -y && \
   apt-get install -y \
+  bash-completion \
   containerd.io \
   dialog \
   dnsutils \
@@ -220,7 +221,8 @@ RUN \
   terraform \
   vim \
   wabt \
-  xz-utils
+  xz-utils \
+  zsh
 
 # Update gems
 RUN \


### PR DESCRIPTION
zsh is pretty common, and bash-completion is missing to fix completion of tools like kubectl and git